### PR TITLE
Ajouter le partage équitable de l'addition

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -32,7 +32,7 @@ function App() {
           <Menu selectedCategory={selectedCategory} setSelectedCategory={setSelectedCategory} />
         )}
         {page === 'commandes' && <OrdersList tables={tables} />}
-        {page === 'paiement' && <Payment tableNumber={12} />}
+        {page === 'paiement' && <Payment tableNumber={12} tableCapacity={8} />}
       </main>
       {readyNotification && (
         <ReadyNotification message={readyNotification} onClose={() => setReadyNotification(null)} />

--- a/frontend/src/components/common/pop-up/pop-up.scss
+++ b/frontend/src/components/common/pop-up/pop-up.scss
@@ -23,13 +23,13 @@
       margin-bottom: 10px;
       display: flex;
       flex-direction: row;
-      align-items: center;
+      align-items: flex-start;
       justify-content: space-between;
       gap: 10px;
       & .popup-title {
-        margin: 0;
         color: black;
         font-size: 1.2em;
+        margin-top: 5px;
       }
 
       & .popup-close {
@@ -38,13 +38,11 @@
         bottom: 14px;
         left: 10px;
         & .IconButton {
-          align-self: flex-end;
           background: none;
           border: none;
           width: 25px;
           height: 25px;
           cursor: pointer;
-          margin-left: auto;
           & .material-icons {
             font-size: 1em;
             color: black;

--- a/frontend/src/components/common/select-items-checkbox/select-items-checkbox.tsx
+++ b/frontend/src/components/common/select-items-checkbox/select-items-checkbox.tsx
@@ -3,18 +3,25 @@ import './select-items-checkbox.scss';
 type SelectItemsCheckboxProps = {
   readonly label: string;
   readonly checked: boolean;
+  readonly disabled: boolean;
   readonly onChange: (checked: boolean) => void;
 };
 
 export default function SelectItemsCheckbox({
   label,
   checked,
+  disabled,
   onChange,
 }: Readonly<SelectItemsCheckboxProps>) {
   return (
     <div className="select-items-checkbox">
       <label>
-        <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} />
+        <input
+          type="checkbox"
+          checked={checked}
+          disabled={disabled}
+          onChange={(e) => onChange(e.target.checked)}
+        />
         {label}
       </label>
     </div>

--- a/frontend/src/components/payment/item-detail/item-detail.tsx
+++ b/frontend/src/components/payment/item-detail/item-detail.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react';
 
 export type ItemDetailProps = {
   name: string;
+  disabled: boolean;
   quantity: number;
   selected: boolean;
   selectedQuantity: number;
@@ -10,16 +11,9 @@ export type ItemDetailProps = {
   onQuantityChange: (value: number) => void;
 };
 
-export function ItemDetail({
-  name,
-  quantity,
-  selected,
-  selectedQuantity,
-  onSelectChange,
-  onQuantityChange,
-}: Readonly<ItemDetailProps>) {
+export function ItemDetail(props: Readonly<ItemDetailProps>) {
   const checkboxRef = useRef<HTMLInputElement>(null);
-  const isIndeterminate = selectedQuantity > 0 && selectedQuantity < quantity;
+  const isIndeterminate = props.selectedQuantity > 0 && props.selectedQuantity < props.quantity;
 
   useEffect(() => {
     if (checkboxRef.current) {
@@ -30,29 +24,31 @@ export function ItemDetail({
   return (
     <div className="item-detail-card">
       <div className="item-header">
-        <h1 className="item-title">{name}</h1>
+        <h1 className="item-title">{props.name}</h1>
         <input
           className="item-checkbox"
           type="checkbox"
+          disabled={props.disabled}
           ref={checkboxRef}
-          checked={selected}
-          onChange={(e) => onSelectChange(e.target.checked)}
+          checked={props.selected}
+          onChange={(e) => props.onSelectChange(e.target.checked)}
         />
       </div>
       <div className="item-quantity">
         <label htmlFor="quantity-select">Quantité :</label>
         <select
           className="quantity-select"
-          value={selectedQuantity}
-          onChange={(e) => onQuantityChange(Number(e.target.value))}
+          disabled={props.disabled}
+          value={props.selectedQuantity}
+          onChange={(e) => props.onQuantityChange(Number(e.target.value))}
         >
-          {[...Array(quantity + 1).keys()].map((i) => (
+          {[...new Array(props.quantity + 1).keys()].map((i) => (
             <option key={i} value={i}>
               {i}
             </option>
           ))}
         </select>
-        <span>/ {quantity}</span>
+        <span>/ {props.quantity}</span>
       </div>
     </div>
   );

--- a/frontend/src/components/payment/payment-summary/normal-payment-summary.tsx
+++ b/frontend/src/components/payment/payment-summary/normal-payment-summary.tsx
@@ -1,0 +1,39 @@
+import './payment-summary.scss';
+import { SplitPopup } from '../split-popup/split-popup.tsx';
+import { useState } from 'react';
+
+export type PaymentBarProps = {
+  readonly total: number;
+  readonly toPay: number;
+  readonly tableCapacity: number;
+  readonly onSplit: (divider: number) => void;
+  readonly onPay: () => void;
+};
+
+export function NormalPaymentSummary(props: Readonly<PaymentBarProps>) {
+  const [isSplitPopupOpen, setIsSplitPopupOpen] = useState(false);
+
+  return (
+    <div className="payment-summary-container">
+      <div className="payment-summary-info">
+        <span className="label">Reste à payer :</span>
+        <span className="amount">{props.total.toFixed(2)}€</span>
+      </div>
+      <div className="payment-actions">
+        <button className="btn split" onClick={() => setIsSplitPopupOpen(true)}>
+          Partager équitablement
+        </button>
+        <SplitPopup
+          isOpen={isSplitPopupOpen}
+          onClose={() => setIsSplitPopupOpen(false)}
+          onSplit={props.onSplit}
+          title={'Pour combien de personnes diviser cette addition ?'}
+          splitMax={props.tableCapacity}
+        />
+        <button className="btn pay" onClick={props.onPay}>
+          Payer : {props.toPay.toFixed(2)}€
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/payment/payment-summary/payment-summary.scss
+++ b/frontend/src/components/payment/payment-summary/payment-summary.scss
@@ -1,6 +1,6 @@
 .payment-summary-container {
   display: flex;
-  margin: 0 2% 2% 2%;
+  margin: 0 2% 2% 0;
   justify-content: space-between;
   align-items: center;
 
@@ -16,6 +16,10 @@
     .amount {
       color: #111;
       font-weight: 600;
+    }
+
+    span:nth-child(2) {
+      margin-right: 2rem;
     }
   }
 

--- a/frontend/src/components/payment/payment-summary/split-payment-summary.tsx
+++ b/frontend/src/components/payment/payment-summary/split-payment-summary.tsx
@@ -1,25 +1,24 @@
 import './payment-summary.scss';
 
-export type PaymentBarProps = {
+export type SplitPaymentSummaryProps = {
   readonly total: number;
-  readonly toPay: number;
-  readonly onSplit: () => void;
+  readonly amountPerPerson: number;
+  readonly remainingPeople: number;
   readonly onPay: () => void;
 };
 
-export function PaymentSummary(props: Readonly<PaymentBarProps>) {
+export function SplitPaymentSummary(props: Readonly<SplitPaymentSummaryProps>) {
   return (
     <div className="payment-summary-container">
       <div className="payment-summary-info">
         <span className="label">Reste à payer :</span>
         <span className="amount">{props.total.toFixed(2)}€</span>
+        <span className="label">Paiements restants :</span>
+        <span className="amount">{props.remainingPeople}</span>
       </div>
       <div className="payment-actions">
-        <button className="btn split" onClick={props.onSplit}>
-          Partager équitablement
-        </button>
         <button className="btn pay" onClick={props.onPay}>
-          Payer : {props.toPay.toFixed(2)}€
+          Payer : {props.amountPerPerson.toFixed(2)}€
         </button>
       </div>
     </div>

--- a/frontend/src/components/payment/split-popup/split-popup.scss
+++ b/frontend/src/components/payment/split-popup/split-popup.scss
@@ -1,0 +1,67 @@
+.slider-container {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin: 2rem auto;
+  width: 80%;
+
+  .min-label {
+    font-size: 1rem;
+    color: #666;
+    min-width: 20px;
+  }
+
+  input[type='range'] {
+    flex: 1;
+    height: 8px;
+    border-radius: 5px;
+    background: #ddd;
+    outline: none;
+    appearance: none;
+
+    &::-webkit-slider-thumb {
+      appearance: none;
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: var(--palette-green-valid);
+      cursor: pointer;
+    }
+
+    &::-moz-range-thumb {
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: var(--palette-green-valid);
+      cursor: pointer;
+      border: none;
+    }
+  }
+
+  .max-label {
+    font-size: 1rem;
+    color: #666;
+    min-width: 20px;
+  }
+}
+
+.split-popup-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 2rem;
+
+  .btn {
+    font-size: 1.25rem;
+    padding: 0.5rem;
+    border-radius: 0.25rem;
+    cursor: pointer;
+    border: solid 0.1rem #000000;
+    background: var(--palette-green-valid);
+    color: white;
+    width: 10rem;
+
+    &:hover {
+      background: var(--palette-green-dark);
+    }
+  }
+}

--- a/frontend/src/components/payment/split-popup/split-popup.tsx
+++ b/frontend/src/components/payment/split-popup/split-popup.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { PopUp } from '../../common/pop-up/pop-up.tsx';
+
+import './split-popup.scss';
+
+export type SplitPopupProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onSplit: (divider: number) => void;
+  readonly title: string;
+  readonly splitMax: number;
+};
+
+export function SplitPopup(props: Readonly<SplitPopupProps>) {
+  const [sliderValue, setSliderValue] = useState(1);
+
+  return (
+    <PopUp isOpen={props.isOpen} onClose={props.onClose} title={props.title}>
+      <div className="slider-container">
+        <span className="min-label">1</span>
+        <input
+          type="range"
+          min={1}
+          max={props.splitMax}
+          value={sliderValue}
+          step={1}
+          onChange={(e) => {
+            const value = Number(e.target.value);
+            setSliderValue(value);
+          }}
+        />
+        <span className="max-label">{props.splitMax}</span>
+      </div>
+      <div className="split-popup-actions">
+        <button
+          className="btn"
+          onClick={() => {
+            props.onSplit(sliderValue);
+            props.onClose();
+          }}
+        >
+          Diviser en {sliderValue}
+        </button>
+      </div>
+    </PopUp>
+  );
+}

--- a/frontend/src/pages/payment.scss
+++ b/frontend/src/pages/payment.scss
@@ -33,6 +33,6 @@
   .payment-summary-separator {
     border: none;
     border-top: 4px solid var(--palette-gray);
-    margin: 2% 2% 2% 2%;
+    margin: 2% 2% 2% 0;
   }
 }

--- a/frontend/src/pages/payment.tsx
+++ b/frontend/src/pages/payment.tsx
@@ -4,11 +4,13 @@ import { mockCommandItems } from '../mocks/command-items.ts';
 import { mockFoodCategories } from '../mocks/food-categories.ts';
 import SelectItemsCheckbox from '../components/common/select-items-checkbox/select-items-checkbox.tsx';
 import { ItemDetail } from '../components/payment/item-detail/item-detail.tsx';
-import { PaymentSummary } from '../components/payment/payment-summary/payment-summary.tsx';
 import type { CommandItem } from '../models/CommandItem.ts';
+import { SplitPaymentSummary } from '../components/payment/payment-summary/split-payment-summary.tsx';
+import { NormalPaymentSummary } from '../components/payment/payment-summary/normal-payment-summary.tsx';
 
 export type PaymentProps = {
   readonly tableNumber: number;
+  readonly tableCapacity: number;
 };
 
 export function Payment(props: PaymentProps) {
@@ -21,108 +23,154 @@ export function Payment(props: PaymentProps) {
     initialSelectedQuantity
   );
 
-  const total = commandItems.reduce((sum, item) => sum + item.price * item.quantity, 0);
-  const toPay = commandItems.reduce((sum, item) => sum + item.price * selectedQuantity[item.id], 0);
+  const [isSplitEquallyMode, setIsSplitEquallyMode] = useState(false);
+  const [remainingPeople, setRemainingPeople] = useState(0);
+  const [totalToSplit, setTotalToSplit] = useState(0);
+  const [initialPeopleCount, setInitialPeopleCount] = useState(0);
 
-  const handlePay = () => {
-    setCommandItems((prev) =>
-      prev
-        .map((item) => {
-          const paidQty = selectedQuantity[item.id] || 0;
-          if (paidQty >= item.quantity) return null;
-          if (paidQty > 0) return { ...item, quantity: item.quantity - paidQty };
-          return item;
-        })
-        .filter((item): item is CommandItem => item !== null)
-    );
-    setSelected(Object.fromEntries(commandItems.map((item) => [item.id, false])));
-    setSelectedQuantity(Object.fromEntries(commandItems.map((item) => [item.id, 0])));
-  };
+  const baseTotal = commandItems.reduce((sum, item) => sum + item.price * item.quantity, 0);
+  const amountPerPerson = initialPeopleCount > 0 ? totalToSplit / initialPeopleCount : 0;
 
-  const handleSelectAll = (checked: boolean) => {
+  const total = isSplitEquallyMode ? remainingPeople * amountPerPerson : baseTotal;
+  const toPay = isSplitEquallyMode
+    ? amountPerPerson
+    : commandItems.reduce((sum, item) => sum + item.price * selectedQuantity[item.id], 0);
+
+  function handlePay() {
+    if (isSplitEquallyMode) {
+      const newRemainingPeople = remainingPeople - 1;
+      setRemainingPeople(newRemainingPeople);
+
+      if (newRemainingPeople === 0) {
+        setCommandItems([]);
+        setIsSplitEquallyMode(false);
+        setRemainingPeople(0);
+        setTotalToSplit(0);
+        setInitialPeopleCount(0);
+      }
+    } else {
+      setCommandItems((prev) =>
+        prev
+          .map((item) => {
+            const paidQty = selectedQuantity[item.id] || 0;
+            if (paidQty >= item.quantity) return null;
+            if (paidQty > 0) return { ...item, quantity: item.quantity - paidQty };
+            return item;
+          })
+          .filter((item): item is CommandItem => item !== null)
+      );
+      setSelected(Object.fromEntries(commandItems.map((item) => [item.id, false])));
+      setSelectedQuantity(Object.fromEntries(commandItems.map((item) => [item.id, 0])));
+    }
+  }
+
+  function handleSplit(divider: number) {
+    const currentTotal = commandItems.reduce((sum, item) => sum + item.price * item.quantity, 0);
+    setTotalToSplit(currentTotal);
+    setInitialPeopleCount(divider);
+    setIsSplitEquallyMode(true);
+    setRemainingPeople(divider);
+  }
+
+  function handleSelectAll(checked: boolean) {
     const newSelected = Object.fromEntries(commandItems.map((item) => [item.id, checked]));
     const newSelectedQuantity = Object.fromEntries(
       commandItems.map((item) => [item.id, checked ? item.quantity : 0])
     );
     setSelected(newSelected);
     setSelectedQuantity(newSelectedQuantity);
-  };
-
-  function handleItemSelectChange(
-    checked: boolean,
-    itemId: number,
-    selected: { [id: number]: boolean },
-    setSelected: Dispatch<SetStateAction<{ [id: number]: boolean }>>,
-    setSelectedQuantity: Dispatch<SetStateAction<{ [id: number]: number }>>
-  ) {
-    setSelected({ ...selected, [itemId]: checked });
-    setSelectedQuantity((prev: { [id: number]: number }) => ({
-      ...prev,
-      [itemId]: checked ? 1 : 0,
-    }));
-  }
-
-  function handleItemQuantityChange(
-    value: number,
-    itemId: number,
-    setSelectedQuantity: Dispatch<SetStateAction<{ [id: number]: number }>>,
-    setSelected: Dispatch<SetStateAction<{ [id: number]: boolean }>>
-  ) {
-    setSelectedQuantity((prev: { [id: number]: number }) => ({ ...prev, [itemId]: value }));
-    setSelected((prev: { [id: number]: boolean }) => ({ ...prev, [itemId]: value >= 1 }));
   }
 
   return (
-    <>
-      <div className="payment-container">
-        <div className="header">
-          <h1>Table {props.tableNumber}</h1>
-          <hr className="payment-table-separator" />
-          <SelectItemsCheckbox
-            label="Sélectionner tout"
-            checked={commandItems.every((item) => selectedQuantity[item.id] === item.quantity)}
-            onChange={handleSelectAll}
-          />
-        </div>
-        <div className="items-container">
-          {mockFoodCategories
-            .filter((category) => commandItems.some((item) => item.categoryId === category.id))
-            .map((category) => (
-              <div key={category.id}>
-                <h2>{category.title}</h2>
-                <div className="items-category-container">
-                  {commandItems
-                    .filter((item) => item.categoryId === category.id)
-                    .map((item) => (
-                      <ItemDetail
-                        key={item.id}
-                        name={item.name}
-                        quantity={item.quantity}
-                        selected={selected[item.id]}
-                        selectedQuantity={selectedQuantity[item.id]}
-                        onSelectChange={(checked) =>
-                          handleItemSelectChange(
-                            checked,
-                            item.id,
-                            selected,
-                            setSelected,
-                            setSelectedQuantity
-                          )
-                        }
-                        onQuantityChange={(value) =>
-                          handleItemQuantityChange(value, item.id, setSelectedQuantity, setSelected)
-                        }
-                      />
-                    ))}
-                </div>
-              </div>
-            ))}
-        </div>
-        <div className="payment-summary-fixed">
-          <hr className="payment-summary-separator" />
-          <PaymentSummary total={total} toPay={toPay} onSplit={() => {}} onPay={handlePay} />
-        </div>
+    <div className="payment-container">
+      <div className="header">
+        <h1>Table {props.tableNumber}</h1>
+        <hr className="payment-table-separator" />
+        <SelectItemsCheckbox
+          label="Sélectionner tout"
+          disabled={isSplitEquallyMode}
+          checked={commandItems.every((item) => selectedQuantity[item.id] === item.quantity)}
+          onChange={handleSelectAll}
+        />
       </div>
-    </>
+      <div className="items-container">
+        {mockFoodCategories
+          .filter((category) => commandItems.some((item) => item.categoryId === category.id))
+          .map((category) => (
+            <div key={category.id}>
+              <h2>{category.title}</h2>
+              <div className="items-category-container">
+                {commandItems
+                  .filter((item) => item.categoryId === category.id)
+                  .map((item) => (
+                    <ItemDetail
+                      key={item.id}
+                      name={item.name}
+                      disabled={isSplitEquallyMode}
+                      quantity={item.quantity}
+                      selected={selected[item.id]}
+                      selectedQuantity={selectedQuantity[item.id]}
+                      onSelectChange={(checked) =>
+                        handleItemSelectChange(
+                          checked,
+                          item.id,
+                          selected,
+                          setSelected,
+                          setSelectedQuantity
+                        )
+                      }
+                      onQuantityChange={(value) =>
+                        handleItemQuantityChange(value, item.id, setSelectedQuantity, setSelected)
+                      }
+                    />
+                  ))}
+              </div>
+            </div>
+          ))}
+      </div>
+      <div className="payment-summary-fixed">
+        <hr className="payment-summary-separator" />
+        {isSplitEquallyMode ? (
+          <SplitPaymentSummary
+            total={total}
+            amountPerPerson={toPay}
+            remainingPeople={remainingPeople}
+            onPay={handlePay}
+          />
+        ) : (
+          <NormalPaymentSummary
+            total={total}
+            toPay={toPay}
+            tableCapacity={props.tableCapacity}
+            onSplit={handleSplit}
+            onPay={handlePay}
+          />
+        )}
+      </div>
+    </div>
   );
+}
+
+function handleItemSelectChange(
+  checked: boolean,
+  itemId: number,
+  selected: { [id: number]: boolean },
+  setSelected: Dispatch<SetStateAction<{ [id: number]: boolean }>>,
+  setSelectedQuantity: Dispatch<SetStateAction<{ [id: number]: number }>>
+) {
+  setSelected({ ...selected, [itemId]: checked });
+  setSelectedQuantity((prev: { [id: number]: number }) => ({
+    ...prev,
+    [itemId]: checked ? 1 : 0,
+  }));
+}
+
+function handleItemQuantityChange(
+  value: number,
+  itemId: number,
+  setSelectedQuantity: Dispatch<SetStateAction<{ [id: number]: number }>>,
+  setSelected: Dispatch<SetStateAction<{ [id: number]: boolean }>>
+) {
+  setSelectedQuantity((prev: { [id: number]: number }) => ({ ...prev, [itemId]: value }));
+  setSelected((prev: { [id: number]: boolean }) => ({ ...prev, [itemId]: value >= 1 }));
 }


### PR DESCRIPTION
Vous avez ce que ça rend en dessous. Je suis un peu sceptique. 
Je me demandais si ce serait pas mieux d'avoir quand on procède au paiement dès le début un choix à faire pour savoir si le paiement sera individuel (avec possibilité de partager des plats), si ça sera partagé équitablement ou payé en totalité. Ca éviterait d'avoir tout dans la même vue. 
Parce que là j'ai adapté la vue ou on divise l'addition à celle d'avant parce que c'était plus simple alors que je pouvais faire carrément une autre vue plus intuitive.
Sinon niveau code je pense qu'il va falloir que je sépare parce que payment.tsx commence à être gros je sais pas si je le fais mtn ou plus tard. 
Dites moi si vous auriez fait autrement ou si c'est bien comme ça et je passe à la suite.  
<img width="1174" height="907" alt="image" src="https://github.com/user-attachments/assets/2e77f67a-ada6-4a75-aaad-ab1b801cb855" />
<img width="1177" height="897" alt="image" src="https://github.com/user-attachments/assets/817eecf2-b140-45c3-9800-e9ff3892d676" />
