### PR TITLE
Paiement partagé par item

### DIFF
--- a/frontend/src/components/payment/item-detail/item-detail.scss
+++ b/frontend/src/components/payment/item-detail/item-detail.scss
@@ -1,7 +1,7 @@
 .item-detail-card {
   border: 1px solid #000;
   border-radius: 0.5rem;
-  width: 14rem;
+  width: 17rem;
   background-color: var(--palette-gray-light);
   padding: 1rem;
 
@@ -28,7 +28,13 @@
     font-size: 1.3rem;
     display: flex;
     align-items: center;
+    justify-content: space-between;
     margin-top: 1rem;
+
+    .quantity-info {
+      display: flex;
+      align-items: center;
+    }
 
     .quantity-select {
       font-size: 1.2rem;
@@ -42,6 +48,36 @@
       option {
         font-size: 1.25rem;
       }
+    }
+  }
+
+  .share-btn {
+    width: 2.2rem;
+    height: 2.2rem;
+    border-radius: 50%;
+    border: 0.1rem solid #000;
+    background-color: white;
+    color: var(--palette-green-dark);
+    font-size: 1.8rem;
+    font-weight: bold;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    transition: all 0.2s ease;
+    padding: 0;
+    line-height: 1;
+    transform: translateY(-1px);
+    margin-right: -0.2rem;
+    outline: none;
+
+    &:hover:not(:disabled) {
+      background-color: var(--palette-green);
+      color: white;
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.6;
     }
   }
 }

--- a/frontend/src/components/sidebar/sidebar.tsx
+++ b/frontend/src/components/sidebar/sidebar.tsx
@@ -1,6 +1,5 @@
 import AppButton from '../common/app-button/app-button.tsx';
 import './sidebar.scss';
-import { OrderService } from '../../services/order-service.ts';
 
 type SidebarProps = {
   onSelect: (page: 'tables' | 'menu' | 'commandes' | 'paiement') => void;
@@ -15,7 +14,7 @@ export default function Sidebar({ onSelect }: Readonly<SidebarProps>) {
         label="Commandes"
         onClick={() => {
           onSelect('commandes');
-          OrderService.getReadyOrders().then((r) => console.log(r));
+          //OrderService.getReadyOrders().then((r) => console.log(r)); La fonction existait plus
         }}
       />
     </div>

--- a/frontend/src/models/Category.ts
+++ b/frontend/src/models/Category.ts
@@ -1,18 +1,18 @@
 export const Category = {
+  BEVERAGE: 'BEVERAGE',
   STARTER: 'STARTER',
   MAIN: 'MAIN',
   DESSERT: 'DESSERT',
-  BEVERAGE: 'BEVERAGE',
 } as const;
 
 export type Category = (typeof Category)[keyof typeof Category];
 
 export function getCategoryTitle(category: Category): string {
   const categoryTitles = {
+    [Category.BEVERAGE]: 'Boissons',
     [Category.STARTER]: 'Entrées',
     [Category.MAIN]: 'Plats',
     [Category.DESSERT]: 'Desserts',
-    [Category.BEVERAGE]: 'Boissons',
   };
   return categoryTitles[category];
 }

--- a/frontend/src/models/CommandItem.ts
+++ b/frontend/src/models/CommandItem.ts
@@ -2,4 +2,5 @@ import type { Item } from './Item.ts';
 
 export interface CommandItem extends Item {
   quantity: number;
+  divider?: number;
 }


### PR DESCRIPTION
Vu que le process pour faire une commande est pas implémenté ça va être compliqué à tester pour vous.
Pour le dev j'ai remis les mocks du coup je peux quand même vous montrer comment ça rend avec des screens.

Nouveau bouton diviser : 
<img width="473" height="261" alt="image" src="https://github.com/user-attachments/assets/330d2ef8-237c-444e-8697-dae1c7cb69f2" />

Qui ouvre cette pop up : 
<img width="945" height="309" alt="image" src="https://github.com/user-attachments/assets/be6fafc6-38fb-43cd-8cf3-9f558b8d9ff2" />

Si on divise par 2 (on peut alors payer la moitié d'un item) :
<img width="326" height="129" alt="image" src="https://github.com/user-attachments/assets/8419ad7b-1478-4f56-8fa6-d48d5734398e" />

On a les différentes options : 
<img width="945" height="524" alt="image" src="https://github.com/user-attachments/assets/33dbb002-ce62-4219-ae06-0799da6ac9a7" />
